### PR TITLE
NavBar scrolls with screen and doesn't clip left or right containers on Home

### DIFF
--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -13,10 +13,13 @@ import { ReactComponent as CollapseIcon } from "../images/navbar_collapse_icon.s
 import { Autocomplete } from "@material-ui/lab";
 import { TextField } from "@material-ui/core";
 import LinkEffect from "../shared/Effect/LinkEffect";
+import StickyEffect from "../shared/Effect/StickyEffect";
 import Setting from "./Setting";
 
 import { AskAvatar } from "../pages/Home/StyleLanding";
 const NavBarWrapper = styled.div`
+  ${StickyEffect}
+  z-index: 4;
   display: flex;
   border-bottom: 1px solid ${colors.black};
   height: max(45px, 4%);

--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -133,6 +133,7 @@ const Home = () => {
         <NavBar setPage={setPage}></NavBar>
         <LandingPageWrapper>
           <LeftContainer>
+            <div style={{ width: "100%", height: "4em" }}></div>
             <InfoBoxes>
               <InfoEntryWrapper
                 onClick={() => history.push(`/user/${user._id}`)}
@@ -213,6 +214,7 @@ const Home = () => {
 
           <RightContainer>
             <CalanderWrapper onClick={() => setErrorPopup(true)}>
+              <div style={{ width: "100%", height: "4em" }}></div>
               <Calendar></Calendar>
             </CalanderWrapper>
             {page === "events" ? (

--- a/src/pages/Home/StyleLanding.js
+++ b/src/pages/Home/StyleLanding.js
@@ -37,21 +37,24 @@ export const LandingPageWrapper = styled.div`
 `;
 
 export const LeftContainer = styled.div`
-  ${StickyEffect};
+  ${StickyEffect}
   white-space: nowrap;
+  margin-top: -5em;
 `;
 
-export const MiddleContainer = styled.div``;
+export const MiddleContainer = styled.div`
+  grid-column: 2/3;
+`;
 
 export const RightContainer = styled.div`
-  ${StickyEffect};
+  ${StickyEffect}
   display: flex;
   flex-direction: column;
   gap: 20px;
+  margin-top: -5em;
 `;
 
 export const InfoBoxes = styled.div`
-  ${StickyEffect}
   height: 235px;
   background-color: ${colors.white};
   border-radius: 5px;
@@ -92,7 +95,6 @@ export const InfoProfilePic = styled(InfoImage)`
 `;
 
 export const FilterWrapper = styled.div`
-  ${StickyEffect}
   box-sizing: border-box;
   margin-top: 20px;
   padding: 20px;


### PR DESCRIPTION
Accomplished using these changes:

* NavBar.js component was modified to be sticky
* Home.js modified so that there is a \<div\> that adds space under left and right containers so that the navbar doesn't
clip it
* No real changes to StyleLanding.js