### PR TITLE
Added tag fixes for new post, sticky expand file

### DIFF
--- a/src/components/NewPost.js
+++ b/src/components/NewPost.js
@@ -126,40 +126,93 @@ const NewPost = ({ open, handleClose }) => {
     }
     if (form.name === null) {
       if (imgForm.name === null) {
-        post = {
-          title: title,
-          body: description,
-          tags: [industry],
-        };
-        if (resources) {
-          post.tags = [...post.tags, "resource"];
+        if (industry.trim().length < 1) {
+          post = {
+            title: title,
+            body: description,
+            tags: null,
+          };
+          if (resources) {
+            post.tags = ["resource"];
+          }
+        } else {
+          post = {
+            title: title,
+            body: description,
+            tags: [industry],
+          };
+          if (resources) {
+            post.tags = [...post.tags, "resource"];
+          }
         }
       } else {
-        post = {
-          title: title,
-          body: description,
-          tags: [industry],
-          files: [imgForm],
-        };
-        if (resources) {
-          post.tags = [...post.tags, "resource"];
+        if (industry.trim().length < 1) {
+          post = {
+            title: title,
+            body: description,
+            files: [imgForm],
+            tags: null,
+          };
+          if (resources) {
+            post.tags = ["resource"];
+          }
+        } else {
+          post = {
+            title: title,
+            body: description,
+            tags: [industry],
+            files: [imgForm],
+          };
+          if (resources) {
+            post.tags = [...post.tags, "resource"];
+          }
         }
       }
     } else {
       if (imgForm.name === null) {
-        post = {
-          title: title,
-          body: description,
-          tags: [industry, "resource"],
-          files: [form],
-        };
+        if (industry.trim().length < 1) {
+          post = {
+            title: title,
+            body: description,
+            tags: null,
+            files: [form],
+          };
+          if (resources) {
+            post.tags = ["resource"];
+          }
+        } else {
+          post = {
+            title: title,
+            body: description,
+            tags: [industry],
+            files: [form],
+          };
+          if (resources) {
+            post.tags = [...post.tags, "resource"];
+          }
+        }
       } else {
-        post = {
-          title: title,
-          body: description,
-          tags: [industry, "resource"],
-          files: [form, imgForm],
-        };
+        if (industry.trim().length < 1) {
+          post = {
+            title: title,
+            body: description,
+            tags: null,
+            files: [form, imgForm],
+          };
+          if (resources) {
+            post.tags = ["resource"];
+          }
+        } else {
+          post = {
+            title: title,
+            body: description,
+            tags: [industry],
+            files: [form, imgForm],
+          };
+          if (resources) {
+            post.tags = [...post.tags, "resource"];
+          }
+        }
       }
     }
 

--- a/src/pages/Home/Posts.js
+++ b/src/pages/Home/Posts.js
@@ -67,6 +67,10 @@ const LikeCommentCount = styled.div`
 `;
 
 export const FileButton = styled(Button)`
+  position: sticky;
+  top: 0;
+  align-self: start;
+  z-index: 100;
   width: 89px;
   height: 30px;
   border-radius: 8px;


### PR DESCRIPTION
I fixed the tag errors we were having(blank tags when no industry is selected, resource tags appearing on non-resource posts) as well as making the expand file button sticky.